### PR TITLE
[#60] Amount(value: Double) false positive tooManyFractionalDigits

### DIFF
--- a/Sources/ZcashPaymentURI/Model.swift
+++ b/Sources/ZcashPaymentURI/Model.swift
@@ -40,7 +40,7 @@ public struct Payment: Equatable {
     public init(
         recipientAddress: RecipientAddress,
         amount: Amount,
-        memo: MemoBytes?, 
+        memo: MemoBytes?,
         label: String?,
         message: String?,
         otherParams: [OtherParam]?

--- a/Tests/ZcashPaymentURITests/AmountTests.swift
+++ b/Tests/ZcashPaymentURITests/AmountTests.swift
@@ -54,4 +54,40 @@ final class AmountTests: XCTestCase {
     func testAmountParsesMaxAmount() throws {
         XCTAssertEqual(try Amount(string: "21000000").toString(), try Amount(value: 21_000_000).toString())
     }
+
+    func testDoubleToDecimal() throws {
+
+        var result = Decimal()
+        var number = Decimal(10_000.00002)
+
+        NSDecimalRound(&result, &number, Amount.maxFractionalDecimalDigits, .bankers)
+        
+        let amount = try Amount(value: 10_000.00002)
+        XCTAssertEqual(amount.toString(), "10000.00002")
+    }
+
+    func testFractionsOfZecFromDouble() throws {
+       // XCTAssertEqual(try Amount(value: 0.2).toString(), "0.2")
+        XCTAssertEqual(try Amount(value: 0.02).toString(), "0.02")
+        XCTAssertEqual(try Amount(value: 0.002).toString(), "0.002")
+        XCTAssertEqual(try Amount(value: 0.0002).toString(), "0.0002")
+        XCTAssertEqual(try Amount(value: 0.00002).toString(), "0.00002")
+        XCTAssertEqual(try Amount(value: 0.000002).toString(), "0.000002")
+        XCTAssertEqual(try Amount(value: 0.0000002).toString(), "0.0000002")
+        XCTAssertEqual(try Amount(value: 0.00000002).toString(), "0.00000002")
+        XCTAssertEqual(try Amount(value: 0.2).toString(), "0.2")
+        XCTAssertEqual(try Amount(value: 10.02).toString(), "10.02")
+        XCTAssertEqual(try Amount(value: 100.002).toString(), "100.002")
+        XCTAssertEqual(try Amount(value: 1_000.0002).toString(), "1000.0002")
+        XCTAssertEqual(try Amount(value: 10_000.00002).toString(), "10000.00002")
+        XCTAssertEqual(try Amount(value: 100_000.000002).toString(), "100000.000002")
+        XCTAssertEqual(try Amount(value: 1_000_000.0000002).toString(), "1000000.0000002")
+        XCTAssertEqual(try Amount(value: 10_000_000.00000002).toString(), "10000000.00000002")
+    }
+
+    func testTooManyFractionsThrows() throws {
+        //more digits than supposed to
+        XCTAssertThrowsError(try Amount(decimal: Decimal(0.000000002)).toString())
+        XCTAssertThrowsError(try Amount(decimal: Decimal(10_000_000.000000002)))
+    }
 }


### PR DESCRIPTION
This commit adds tests to reproduce the described case and several checks and changes on how `Double` inputs are used to initialize an `Amount`. This branches off the rounding of inputs to let the caller chose whether to round the input when creating an Amount and also removes the rounding from the `toString()` method to avoid rouding twice when printing the number to a String 

Closes #60