### PR TITLE
[v2 base] Add shared ZIP-321 conformance corpus and expected-failure conformance runner

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
 
 jobs:
   build:
@@ -23,6 +22,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - name: Setup Swift ${{ matrix.swift }}
         if: ${{ matrix.use-setup-swift }}
         uses: swift-actions/setup-swift@v2

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Tests/Vectors"]
+	path = Tests/Vectors
+	url = https://github.com/zecdev/zcash-zip321-test-vectors.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- The shared ZIP-321 conformance vector corpus
+  ([zcash-zip321-test-vectors](https://github.com/zecdev/zcash-zip321-test-vectors),
+  oracle-verified against the librustzcash `zip321` reference implementation) is
+  now consumed as a test-only git submodule at `Tests/Vectors`. The `.gitmodules`
+  URL is a temporary local path until the corpus repository is published.
+- A conformance test runner (`Tests/ZcashPaymentURITests/Conformance/`) that
+  parses every corpus vector with `ZIP321.request(from:context:)`, asserts
+  field-level agreement (addresses, exact zatoshi amounts, memos, labels,
+  messages, other params) for valid vectors, rejection for invalid vectors, and
+  compares re-rendered URIs against the Rust reference `canonicalUri`.
+  Known divergences of the current implementation from the reference semantics
+  are enumerated in a strict expected-failure map
+  (`ConformanceExpectedFailures.swift`, checked via `XCTExpectFailure`), so the
+  suite is green today while every gap stays machine-checked: fixing a gap
+  without pruning its map entry turns the suite red. The map currently
+  documents 14 divergences (missing address checksum validation, lenient
+  amount grammar, missing zero-valued-transparent-output check, rejection of
+  empty `memo=`/`message=` values, rejection of regtest Sapling addresses,
+  rejection of empty requests, otherparam decoding/rendering issues, and
+  paramindex loss on re-render).
+
 ## 1.0.0
 This release contains several **API breaking changes**, but let not be discouraged to
 update! These changes are made to add several checks to the library to ensure that your payment

--- a/Tests/ZcashPaymentURITests/Conformance/ConformanceExpectedFailures.swift
+++ b/Tests/ZcashPaymentURITests/Conformance/ConformanceExpectedFailures.swift
@@ -1,0 +1,89 @@
+//
+//  ConformanceExpectedFailures.swift
+//
+//  The v1 gap inventory against the shared ZIP-321 conformance corpus
+//  (`Tests/Vectors`). Every entry maps a corpus vector `name` to the precise
+//  reason the current (v1) implementation diverges from the librustzcash
+//  `zip321` reference semantics for that vector.
+//
+//  Semantics: a vector listed here is asserted to CURRENTLY FAIL via a strict
+//  `XCTExpectFailure`. If a library fix makes the vector pass, the strict
+//  expectation itself fails, flagging the stale entry so it can be deleted.
+//  A vector NOT listed here must pass outright. The conformance suite is
+//  therefore green today while every known divergence stays enumerated and
+//  machine-checked.
+//
+//  This map is intentionally the burn-down list for the v2 rewrite. Entries
+//  must only ever be added from OBSERVED test failures, never speculatively.
+//
+
+/// Vector name → reason the v1 implementation currently fails that vector.
+///
+/// Observed against corpus commit pinned by the `Tests/Vectors` submodule.
+/// Categories used in reasons:
+///   - "v1 accepts": an invalid vector that v1 fails to reject.
+///   - "v1 rejects": a valid vector that v1 fails to parse.
+///   - "fieldMismatch": v1 parses but a decoded field differs from the reference.
+///   - "renderMismatch": v1 parses correctly but its re-rendered URI differs
+///     from the Rust reference `canonicalUri` (documented expectation only).
+let conformanceExpectedFailures: [String: String] = [
+    // MARK: Address validation — v1 is charset/HRP-heuristic only, no checksum
+    "invalid_address_sapling_bad_checksum":
+        "v1 accepts: address validation is HRP-prefix + bech32-charset only; a corrupted "
+        + "bech32 checksum (last char z→q) still satisfies the charset, so no error is raised",
+    "invalid_address_unified_mainnet_bad_checksum":
+        "v1 accepts: no bech32m checksum verification for unified addresses; corrupted "
+        + "checksum passes the u1-prefix + bech32-charset heuristic",
+    "invalid_address_transparent_bad_checksum":
+        "v1 accepts: no base58check checksum verification for transparent addresses; "
+        + "corrupted checksum (last char U→1) still satisfies the base58 charset",
+
+    // MARK: Amount grammar — BigDecimal(string:) is more lenient than the ZIP-321 grammar
+    "invalid_amount_trailing_decimal_point":
+        "v1 accepts: 'amount=123.' parses via BigDecimal to 123; ZIP-321 grammar requires "
+        + "at least one digit after the decimal point",
+    "invalid_amount_leading_decimal_point":
+        "v1 accepts: 'amount=.5' parses via BigDecimal to 0.5; ZIP-321 grammar requires "
+        + "a whole-number part before the decimal point",
+
+    // MARK: Missing consensus check
+    "spec_invalid_zero_valued_transparent_output":
+        "v1 accepts: no check that a zero-valued amount to a transparent recipient is "
+        + "disallowed by consensus; Amount permits 0 and Payment never rejects it",
+
+    // MARK: Empty parameter values — v1's checked types disallow empty strings
+    "amount_one_with_empty_message":
+        "v1 rejects: 'message=' (empty value) throws qcharDecodeFailed because QcharString "
+        + "disallows empty strings; reference accepts an empty message",
+    "amount_parse_simple_large_decimal":
+        "v1 rejects: same empty-'message=' limitation as amount_one_with_empty_message "
+        + "(QcharString disallows empty strings)",
+    "structure_empty_memo_on_sapling":
+        "v1 rejects: 'memo=' (0-byte memo) throws memoBytesError(memoEmpty); reference "
+        + "accepts a zero-length memo as valid",
+
+    // MARK: Regtest Sapling addresses — dead branch in the charset validator
+    "spec_valid_regtest_example":
+        "v1 rejects: onlyCharsetValidation switches on the first two characters and has no "
+        + "'zr' case, so zregtestsapling1... is rejected as invalidAddress even though "
+        + "saplingEncodingCharsetParser has an (unreachable) 'zregtestsapling1' branch",
+
+    // MARK: Zero-payment requests — v1 cannot represent an empty request
+    "structure_empty_request":
+        "v1 rejects: 'zcash:' (a valid empty request per the reference) throws invalidURI; "
+        + "v1's model requires at least one payment",
+    "structure_empty_request_query_marker":
+        "v1 rejects: 'zcash:?' throws otherParamKeyEmpty (the empty query string is parsed "
+        + "as an empty otherparam key); reference parses it as an empty request",
+
+    // MARK: Parsed-model / rendering divergences
+    "structure_index_gap_only_address_5":
+        "renderMismatch: v1's PaymentRequest does not retain ZIP-321 paramindices, so a "
+        + "request whose only payment sits at paramindex 5 re-renders at the empty index "
+        + "(zcash:{addr}?amount=1) where the reference preserves address.5/amount.5",
+    "structure_unknown_param_preserved":
+        "fieldMismatch + renderMismatch: v1 does not percent-decode otherparam values on "
+        + "parse (exposes 'hello%20world' where reference decodes 'hello world'), and "
+        + "Render.parameter(other:) drops the '=' separator and re-encodes the raw value, "
+        + "rendering 'future-paramhello%2520world' instead of 'future-param=hello%20world'"
+]

--- a/Tests/ZcashPaymentURITests/Conformance/ConformanceTests.swift
+++ b/Tests/ZcashPaymentURITests/Conformance/ConformanceTests.swift
@@ -1,0 +1,324 @@
+//
+//  ConformanceTests.swift
+//
+//  Conformance runner for the shared ZIP-321 test vector corpus
+//  (`Tests/Vectors` submodule, oracle-verified against librustzcash `zip321`).
+//
+//  For every vector in `vectors/valid/*.json` the runner asserts that
+//  `ZIP321.request(from:context:)` succeeds and that the parsed model matches
+//  the vector's per-payment expectations (address, zatoshi amount, memo,
+//  label, message, other params), then re-renders the request and compares it
+//  against the Rust-reference `canonicalUri` as a *documented expectation*
+//  (v1's formatting may legitimately differ; mismatches are tracked as
+//  `renderMismatch` entries in the expected-failure map, not treated as
+//  hard requirements).
+//
+//  For every vector in `vectors/invalid/*.json` the runner asserts only that
+//  parsing throws. The corpus's cross-language error discriminants do not map
+//  1:1 onto v1's `ZIP321.Errors` taxonomy, so the exact error case is not
+//  asserted; when a vector unexpectedly *succeeds*, the parsed result is
+//  included in the failure message.
+//
+//  Vectors named in `conformanceExpectedFailures` are asserted to CURRENTLY
+//  FAIL via strict `XCTExpectFailure`: fixing the library without pruning the
+//  map turns the suite red, so the gap inventory can never silently go stale.
+//
+//  The suite is fully deterministic: no network, no clocks, JSON loaded from
+//  the submodule via `#filePath`.
+//
+
+import XCTest
+@testable import ZcashPaymentURI
+
+// swiftlint:disable file_length type_body_length
+final class Zip321ConformanceTests: XCTestCase {
+    // MARK: - Suite
+
+    func testValidVectors() throws {
+        let vectors = try ConformanceCorpus.validVectors()
+        XCTAssertFalse(vectors.isEmpty, "no valid vectors loaded — is the Tests/Vectors submodule initialized?")
+
+        for vector in vectors {
+            runVector(named: vector.name) { self.check(valid: vector) }
+        }
+    }
+
+    func testInvalidVectors() throws {
+        let vectors = try ConformanceCorpus.invalidVectors()
+        XCTAssertFalse(vectors.isEmpty, "no invalid vectors loaded — is the Tests/Vectors submodule initialized?")
+
+        for vector in vectors {
+            runVector(named: vector.name) { self.check(invalid: vector) }
+        }
+    }
+
+    /// Guards the expected-failure map against typos and against corpus bumps
+    /// that rename or remove a vector: every key must name a corpus vector.
+    func testExpectedFailureEntriesExistInCorpus() throws {
+        let knownNames = Set(try ConformanceCorpus.validVectors().map(\.name))
+            .union(try ConformanceCorpus.invalidVectors().map(\.name))
+
+        for name in conformanceExpectedFailures.keys.sorted() {
+            XCTAssertTrue(
+                knownNames.contains(name),
+                "expectedFailures entry '\(name)' does not match any corpus vector name"
+            )
+        }
+    }
+
+    // MARK: - Expected-failure wrapper
+
+    /// Runs a single vector's checks, wrapped in a strict `XCTExpectFailure`
+    /// when the vector is listed in `conformanceExpectedFailures`.
+    private func runVector(named name: String, _ body: @escaping () -> Void) {
+        guard let reason = conformanceExpectedFailures[name] else {
+            body()
+            return
+        }
+
+        #if canImport(ObjectiveC)
+        // Strict (the default): if the vector unexpectedly passes, the stale
+        // xfail entry itself is reported as a failure.
+        XCTExpectFailure("\(name): \(reason)", failingBlock: body)
+        #else
+        // swift-corelibs-xctest (Linux) has no XCTExpectFailure; skip the
+        // vector visibly rather than silently passing or hard-failing.
+        print("[conformance] SKIPPED xfail vector '\(name)' — \(reason)")
+        #endif
+    }
+
+    // MARK: - Valid vector checks
+
+    /// The v1 parsed model normalized for comparison. `ParserResult.legacy`
+    /// (a bare `zcash:{address}` URI) is represented as a single payment with
+    /// only an address, mirroring the reference's single-payment request.
+    private struct NormalizedPayment {
+        let address: String
+        let amount: Amount?
+        let memoBase64: String?
+        let label: String?
+        let message: String?
+        let other: [(name: String, value: String?)]
+    }
+
+    private func normalize(_ result: ParserResult) -> [NormalizedPayment] {
+        switch result {
+        case .legacy(let recipient):
+            return [
+                NormalizedPayment(
+                    address: recipient.value,
+                    amount: nil,
+                    memoBase64: nil,
+                    label: nil,
+                    message: nil,
+                    other: []
+                )
+            ]
+        case .request(let request):
+            return request.payments.map { payment in
+                NormalizedPayment(
+                    address: payment.recipientAddress.value,
+                    amount: payment.amount,
+                    memoBase64: payment.memo?.toBase64URL(),
+                    label: payment.label?.value,
+                    message: payment.message?.value,
+                    other: (payment.otherParams ?? []).map { ($0.key.value, $0.value?.value) }
+                )
+            }
+        }
+    }
+
+    private func check(valid vector: ConformanceValidVector) {
+        guard let context = parserContext(for: vector.network, vectorName: vector.name) else { return }
+
+        let result: ParserResult
+        do {
+            result = try ZIP321.request(from: vector.uri, context: context)
+        } catch {
+            XCTFail("\(vector.name): expected successful parse but threw \(error)")
+            return
+        }
+
+        let parsed = normalize(result)
+
+        guard parsed.count == vector.payments.count else {
+            XCTFail(
+                "\(vector.name): payment count mismatch — expected \(vector.payments.count), got \(parsed.count)"
+            )
+            return
+        }
+
+        // v1's PaymentRequest does not retain ZIP-321 paramindices, so payments
+        // are compared by array position (the corpus orders payments by
+        // ascending paramindex, which matches v1's parse order).
+        for (expected, actual) in zip(vector.payments, parsed) {
+            let subject = "\(vector.name) payment[\(expected.index)]"
+
+            XCTAssertEqual(actual.address, expected.address, "\(subject): address mismatch")
+
+            checkAmount(expected: expected.amountZat, actual: actual.amount, subject: subject)
+
+            XCTAssertEqual(
+                actual.memoBase64,
+                expected.memoBase64,
+                "\(subject): memo mismatch (comparing base64url re-encoding of parsed bytes)"
+            )
+
+            XCTAssertEqual(actual.label, expected.label, "\(subject): label mismatch")
+            XCTAssertEqual(actual.message, expected.message, "\(subject): message mismatch")
+
+            checkOtherParams(expected: expected.other, actual: actual.other, subject: subject)
+        }
+
+        checkRender(vector: vector, result: result)
+    }
+
+    /// Compares the vector's exact zatoshi amount against v1's decimal-ZEC
+    /// `Amount`.
+    ///
+    /// Precision note: v1 stores amounts as `BigDecimal` limited to 8
+    /// fractional digits, and `Amount.toString()` renders a plain (non-
+    /// scientific) decimal string, so scaling that string by 10^8 with exact
+    /// integer string arithmetic is lossless — no floating point, no rounding.
+    /// If a future `Amount` ever rendered scientific notation or more than 8
+    /// fractional digits, the conversion returns `nil` and the test fails
+    /// loudly instead of rounding silently.
+    private func checkAmount(expected: Int64?, actual: Amount?, subject: String) {
+        switch (expected, actual) {
+        case (.none, .none):
+            return
+        case (.some(let zat), .none):
+            XCTFail("\(subject): expected amount of \(zat) zatoshis but v1 parsed no amount")
+        case (.none, .some(let amount)):
+            XCTFail("\(subject): expected no amount but v1 parsed \(amount.toString())")
+        case (.some(let zat), .some(let amount)):
+            let rendered = amount.toString()
+            guard let actualZat = Self.zatoshis(fromDecimalZecString: rendered) else {
+                XCTFail("\(subject): could not losslessly convert v1 amount '\(rendered)' to zatoshis")
+                return
+            }
+            XCTAssertEqual(actualZat, zat, "\(subject): amount mismatch (v1 rendered '\(rendered)')")
+        }
+    }
+
+    /// Exact decimal-ZEC-string → zatoshi conversion using integer string
+    /// arithmetic only. Returns `nil` for anything that is not a plain,
+    /// non-negative decimal with at most 8 fractional digits.
+    static func zatoshis(fromDecimalZecString string: String) -> Int64? {
+        let parts = string.split(separator: ".", omittingEmptySubsequences: false)
+        guard (1...2).contains(parts.count) else { return nil }
+
+        let integerDigits = parts[0].isEmpty ? "0" : String(parts[0])
+        var fractionDigits = parts.count == 2 ? String(parts[1]) : ""
+
+        guard fractionDigits.count <= 8 else { return nil }
+        fractionDigits += String(repeating: "0", count: 8 - fractionDigits.count)
+
+        let isASCIIDigits: (String) -> Bool = { $0.allSatisfy { $0.isASCII && $0.isNumber } }
+        guard
+            isASCIIDigits(integerDigits),
+            isASCIIDigits(fractionDigits),
+            let whole = Int64(integerDigits),
+            let fraction = Int64(fractionDigits)
+        else { return nil }
+
+        return whole * 100_000_000 + fraction
+    }
+
+    private func checkOtherParams(
+        expected: [[String?]],
+        actual: [(name: String, value: String?)],
+        subject: String
+    ) {
+        guard expected.count == actual.count else {
+            XCTFail(
+                "\(subject): otherparam count mismatch — expected \(expected.count) (\(expected)), got \(actual.count) (\(actual))"
+            )
+            return
+        }
+
+        for (index, (expectedPair, actualPair)) in zip(expected, actual).enumerated() {
+            let expectedName = expectedPair.first ?? nil
+            let expectedValue = expectedPair.count > 1 ? expectedPair[1] : nil
+
+            XCTAssertEqual(actualPair.name, expectedName, "\(subject): otherparam[\(index)] name mismatch")
+            XCTAssertEqual(actualPair.value, expectedValue, "\(subject): otherparam[\(index)] value mismatch")
+        }
+    }
+
+    /// Re-renders the parsed request and compares against the Rust reference's
+    /// `canonicalUri`. This is a *documented expectation*, not a spec
+    /// requirement — v1's default formatting may legitimately differ — so any
+    /// mismatch here belongs in the expected-failure map under a
+    /// `renderMismatch:` reason rather than being "fixed" in the runner.
+    ///
+    /// Formatting choice: the librustzcash renderer emits a single payment at
+    /// the empty paramindex as `zcash:{address}?...` (address label omitted)
+    /// and multi-payment requests as `zcash:?address=...&address.1=...`, so
+    /// the closest v1 options are `.useEmptyParamIndex(omitAddressLabel:
+    /// count == 1)`.
+    private func checkRender(vector: ConformanceValidVector, result: ParserResult) {
+        guard let canonical = vector.canonicalUri else { return }
+
+        let rendered: String
+        switch result {
+        case .legacy(let recipient):
+            rendered = ZIP321.request(recipient, formattingOptions: .useEmptyParamIndex(omitAddressLabel: true))
+        case .request(let request):
+            rendered = ZIP321.uriString(
+                from: request,
+                formattingOptions: .useEmptyParamIndex(omitAddressLabel: request.payments.count == 1)
+            )
+        }
+
+        XCTAssertEqual(
+            rendered,
+            canonical,
+            "\(vector.name): renderMismatch — v1 re-render differs from reference canonical URI"
+        )
+    }
+
+    // MARK: - Invalid vector checks
+
+    private func check(invalid vector: ConformanceInvalidVector) {
+        guard let context = parserContext(for: vector.network, vectorName: vector.name) else { return }
+
+        do {
+            let result = try ZIP321.request(from: vector.uri, context: context)
+            XCTFail(
+                "\(vector.name): expected rejection (corpus discriminant: \(vector.error)) "
+                + "but parsing succeeded with \(describe(result))"
+            )
+        } catch {
+            // Pass. Any thrown error counts as rejection: v1's error taxonomy
+            // does not map 1:1 onto the corpus discriminants, so the exact
+            // case is deliberately not asserted.
+        }
+    }
+
+    private func describe(_ result: ParserResult) -> String {
+        switch result {
+        case .legacy(let recipient):
+            return "legacy(\(recipient.value))"
+        case .request(let request):
+            let payments = request.payments.map { payment in
+                "(address: \(payment.recipientAddress.value), amount: \(payment.amount?.toString() ?? "nil"))"
+            }
+            return "request(\(payments.joined(separator: ", ")))"
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func parserContext(for network: String, vectorName: String) -> ParserContext? {
+        switch network {
+        case "main": return .mainnet
+        case "test": return .testnet
+        case "regtest": return .regtest
+        default:
+            XCTFail("\(vectorName): unknown network '\(network)' in corpus vector")
+            return nil
+        }
+    }
+}
+// swiftlint:enable file_length type_body_length

--- a/Tests/ZcashPaymentURITests/Conformance/ConformanceVectors.swift
+++ b/Tests/ZcashPaymentURITests/Conformance/ConformanceVectors.swift
@@ -1,0 +1,95 @@
+//
+//  ConformanceVectors.swift
+//
+//  Codable models and loader for the shared ZIP-321 conformance vector corpus
+//  consumed as a git submodule at `Tests/Vectors`.
+//
+//  See `Tests/Vectors/schema/vector-schema.md` for the authoritative field-by-field
+//  description of both vector shapes and the shared error discriminants.
+//
+
+import Foundation
+
+/// A vector from `vectors/valid/*.json`: a URI that MUST parse, together with
+/// the field-level expectations for every payment it contains.
+struct ConformanceValidVector: Decodable {
+    struct VectorPayment: Decodable {
+        /// The ZIP-321 `paramindex` (0 denotes the empty paramindex). Note that
+        /// v1's parsed model (`PaymentRequest`) does not retain paramindices, so
+        /// the conformance runner compares payments by array position only.
+        let index: UInt
+        /// Recipient address exactly as it appears in the URI.
+        let address: String
+        /// Amount in zatoshis (exact integer), or `nil` if no `amount` param present.
+        let amountZat: Int64?
+        /// The raw base64url-without-padding memo value from the URI, or `nil`
+        /// if no `memo` param is present. `""` means `memo=` (a 0-byte memo).
+        let memoBase64: String?
+        /// Percent-decoded label value, or `nil` if absent.
+        let label: String?
+        /// Percent-decoded message value, or `nil` if absent.
+        let message: String?
+        /// `[name, decodedValue]` pairs for unrecognized non-`req-` params, in order.
+        let other: [[String?]]
+    }
+
+    let name: String
+    let description: String
+    let uri: String
+    let network: String
+    let payments: [VectorPayment]
+    /// Reference (librustzcash `TransactionRequest::to_uri()`) rendering of the
+    /// parsed request; `nil` only for oracle-skipped vectors.
+    let canonicalUri: String?
+    let oracleSkip: Bool
+    let oracleSkipReason: String?
+}
+
+/// A vector from `vectors/invalid/*.json`: a URI that MUST be rejected.
+struct ConformanceInvalidVector: Decodable {
+    let name: String
+    let description: String
+    let uri: String
+    let network: String
+    /// Shared cross-language error discriminant (see schema). The Swift v1 error
+    /// taxonomy does not map 1:1 onto these, so the runner only asserts *that*
+    /// parsing throws, not *which* error it throws.
+    let error: String
+    let oracleSkip: Bool
+    let oracleSkipReason: String?
+}
+
+enum ConformanceCorpus {
+    /// Root of the `Tests/Vectors` submodule, located relative to this source
+    /// file (`Tests/ZcashPaymentURITests/Conformance/ConformanceVectors.swift`)
+    /// via `#filePath`, so no bundle resource wiring is needed.
+    static var corpusRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // ConformanceVectors.swift -> Conformance/
+            .deletingLastPathComponent() // Conformance/ -> ZcashPaymentURITests/
+            .deletingLastPathComponent() // ZcashPaymentURITests/ -> Tests/
+            .appendingPathComponent("Vectors")
+    }
+
+    static func vectorFiles(in subdirectory: String) throws -> [URL] {
+        let dir = corpusRoot
+            .appendingPathComponent("vectors")
+            .appendingPathComponent(subdirectory)
+        return try FileManager.default
+            .contentsOfDirectory(at: dir, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "json" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    }
+
+    static func validVectors() throws -> [ConformanceValidVector] {
+        try vectorFiles(in: "valid").flatMap { url in
+            try JSONDecoder().decode([ConformanceValidVector].self, from: Data(contentsOf: url))
+        }
+    }
+
+    static func invalidVectors() throws -> [ConformanceInvalidVector] {
+        try vectorFiles(in: "invalid").flatMap { url in
+            try JSONDecoder().decode([ConformanceInvalidVector].self, from: Data(contentsOf: url))
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add the shared, oracle-verified ZIP-321 test vector corpus (zcash-zip321-test-vectors) as a test-only git submodule at Tests/Vectors.
- Add an XCTest conformance runner (Tests/ZcashPaymentURITests/Conformance/) that decodes the corpus JSON via Codable models loaded through #filePath, mapping vector networks onto ParserContext.
- For valid vectors: asserts ZIP321.request(from:context:) succeeds and matches per-payment expectations (address, exact zatoshi amount via lossless integer-string arithmetic, memo, decoded label/message, other params), then re-renders and compares against the Rust reference canonicalUri.
- For invalid vectors: asserts parsing throws; the corpus error discriminants don't map 1:1 onto ZIP321.Errors, so only "throws" is asserted, with unexpected successes reported.
- Enumerates every currently-known divergence from reference semantics in ConformanceExpectedFailures.swift, enforced with strict XCTExpectFailure (a fix that makes a listed vector pass turns the suite red until the entry is pruned); all 14 entries were populated from observed runs only.
- .gitmodules currently points at a temporary local path; will be re-pointed to https://github.com/zecdev/zcash-zip321-test-vectors once published.

## Stack
Part of the v2.0.0 stacked-PR chain. Based on `main` (repository default branch); this is the first PR in the chain.

## Testing
Full existing test suite (137 tests) passes with the new conformance runner (14 known expected-failure entries); no coverage gate yet (introduced later at v2/s16-coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VwH46quaghs7U3VUFV2d3b